### PR TITLE
Remove 'reshape' from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Suggests:
     candisc,
     carData,
     effects,
-    reshape,
     gplots,
     nlme,
     lattice,


### PR DESCRIPTION
The package is ancient and is not referenced anywhere else in the package sources.