### PR TITLE
Suggests: markdown -> litedown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,7 @@ Suggests:
     animation,
     mvinfluence,
     knitr,
+    litedown,
     rmarkdown,
     markdown,
     dplyr,


### PR DESCRIPTION
This PR adds `litedown` to Suggests to prepare for an upcoming change in dependencies in `tinytable`, moving from `markdown` to `litedown`. This follows a recommendation from the NEWS file of the `markdown` package, where Yihui Xie now writes:

> CHANGES IN markdown VERSION 2.0
> The core function mark() is a thin wrapper of litedown::mark() now. 
> Users are recommended to call litedown directly instead of through the wrapper.

Apologies for the trouble.